### PR TITLE
Adding default subnetwork.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,5 +66,5 @@ resource "google_container_cluster" "cluster" {
 
   # node_version (node_pool overrides)
   # project
-  # subnetwork
+  subnetwork = "${local.merged_settings["subnetwork"]}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,6 +7,7 @@ locals {
     http_load_balancing      = true
     daily_maintenance_window = "03:00"
     enable_legacy_abac       = false
+    subnetwork               = "default"
   }
 
   merged_settings = "${merge(local.default_settings, var.settings)}"


### PR DESCRIPTION
Recently TF started to rotate clusters due to subnetwork reassignment:

```
-/+ module.streetworks-dev-cluster.google_container_cluster.cluster (new resource required)
...
      subnetwork:                                                 "default" => "" (forces new resource)
...
```